### PR TITLE
Fixed erroneous approximation caused by using non-unbiased version of variance in TLS 

### DIFF
--- a/Statistics/LinearRegression.hs
+++ b/Statistics/LinearRegression.hs
@@ -66,7 +66,7 @@ linearRegressionTLS :: S.Sample -> S.Sample -> (Double,Double)
 linearRegressionTLS xs ys = (alpha, beta)
     where
           !c                   = covar xs ys
-          !b                   = (S.variance xs - (S.variance ys)) / c
+          !b                   = (S.varianceUnbiased xs - (S.varianceUnbiased ys)) / c
           !m1                  = S.mean xs 
           !m2                  = S.mean ys
           !betas               = [(-b - sqrt(b^2+4))/2,(-b + sqrt(b^2+4)) /2]


### PR DESCRIPTION
TLS used covar, which divides by n-1 to achieve non-biased estimation, on one hand, but S.variance, which divides by n, on the other.
As a result there was some error emerging in the parameters estimation.
Switching to S.varianceUnbiased solved the issue.
